### PR TITLE
fix: handle primitive paths in objectFlow.getByPath

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -136,4 +136,17 @@ describe("objectFlow", () => {
     const result = objectFlow(testObj).find((value) => value > 10);
     expect(result).toBeUndefined();
   });
+
+  test("getByPath retrieves nested values", () => {
+    const nested = { a: { b: { c: 1 }, d: 0, e: false, f: "" } };
+    expect(objectFlow(nested).getByPath(["a", "b", "c"])).toBe(1);
+    expect(objectFlow(nested).getByPath(["a", "d"])).toBe(0);
+    expect(objectFlow(nested).getByPath(["a", "e"])).toBe(false);
+    expect(objectFlow(nested).getByPath(["a", "f"])).toBe("");
+  });
+
+  test("getByPath returns undefined for missing path", () => {
+    const nested = { a: 0 };
+    expect(objectFlow(nested).getByPath(["a", "b"])).toBeUndefined();
+  });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -245,11 +245,13 @@ export function objectFlow<T extends Record<string, any>>(obj: T) {
     },
     getByPath<U>(path: string[]): U | undefined {
       let result: any = obj;
-      path.find((p) => {
-        result = result?.[p];
-        return !result;
-      });
-      return result;
+      for (const p of path) {
+        if (result == null) {
+          return undefined;
+        }
+        result = result[p];
+      }
+      return result as U;
     },
     setByPath(path: string[], value: any) {
       path.reduce((acc, cur, i) => {


### PR DESCRIPTION
## Summary
- correctly handle primitive intermediate values in `objectFlow.getByPath`
- add tests covering nested retrieval and missing paths

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688de86be828832d8a5ec880bef6ae3c